### PR TITLE
Check that root is not symlink

### DIFF
--- a/executor/runc/executor.go
+++ b/executor/runc/executor.go
@@ -46,7 +46,14 @@ func New(root string) (executor.Executor, error) {
 		return nil, err
 	}
 
-	// TODO: check that root is not symlink to fail early
+	// Check that root is not symlink to fail early
+	rootInfo, err := os.Lstat(root)
+	if err != nil {
+		return nil, err
+	}
+	if rootInfo.Mode() & os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%s is a symlink", root)
+    	}
 
 	runtime := &runc.Runc{
 		Log:          filepath.Join(root, "runc-executor-log.json"),


### PR DESCRIPTION
Implements Check that root is not symlink to fail early

https://github.com/jessfraz/img/blob/8e59455cdd12df371ec7babf2a883a656a5a39e1/executor/runc/executor.go#L50