### PR TITLE
Don't leave all target files open when copying context from stdin

### DIFF
--- a/build.go
+++ b/build.go
@@ -267,10 +267,13 @@ func untar(dest string, r io.Reader) error {
 			if err != nil {
 				return err
 			}
-			defer f.Close()
 
 			// copy over contents
-			if _, err := io.Copy(f, tr); err != nil {
+			_, err = io.Copy(f, tr)
+			// immediately close the file, as opposed to doing it in a defer.
+			// This is so we don't leak open files.
+			f.Close()
+			if err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Hi @jessfraz, this just closes target files after write. Previously all target files were being held open for the entire context copy, and I was getting errors about too many open files. Thanks!