### PR TITLE
push: Add insecure-registry flag

### DIFF
--- a/client/push.go
+++ b/client/push.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Push sends an image to a remote registry.
-func (c *Client) Push(ctx context.Context, image string) error {
+func (c *Client) Push(ctx context.Context, image string, insecure bool) error {
 	// Parse the image name and tag.
 	named, err := reference.ParseNormalizedNamed(image)
 	if err != nil {
@@ -30,5 +30,5 @@ func (c *Client) Push(ctx context.Context, image string) error {
 		return fmt.Errorf("getting image %q failed: %v", image, err)
 	}
 
-	return push.Push(ctx, opt.SessionManager, opt.ContentStore, imgObj.Target.Digest, image, false)
+	return push.Push(ctx, opt.SessionManager, opt.ContentStore, imgObj.Target.Digest, image, insecure)
 }

--- a/push.go
+++ b/push.go
@@ -19,10 +19,13 @@ func (cmd *pushCommand) ShortHelp() string { return pushHelp }
 func (cmd *pushCommand) LongHelp() string  { return pushHelp }
 func (cmd *pushCommand) Hidden() bool      { return false }
 
-func (cmd *pushCommand) Register(fs *flag.FlagSet) {}
+func (cmd *pushCommand) Register(fs *flag.FlagSet) {
+	fs.BoolVar(&cmd.insecure, "insecure-registry", false, "Push to insecure registry")
+}
 
 type pushCommand struct {
-	image string
+	image    string
+	insecure bool
 }
 
 func (cmd *pushCommand) Run(args []string) (err error) {
@@ -57,7 +60,7 @@ func (cmd *pushCommand) Run(args []string) (err error) {
 	})
 	eg.Go(func() error {
 		defer sess.Close()
-		return c.Push(ctx, cmd.image)
+		return c.Push(ctx, cmd.image, cmd.insecure)
 	})
 	if err := eg.Wait(); err != nil {
 		return err


### PR DESCRIPTION
related to #85 

moby/buildkit already accept push to insecure registries.

this PR just add the flag to use it.