### PR TITLE
add noembed buildtag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,5 @@ jobs:
       script:
         - make install
         - ./contrib/e2e-dockerfiles-build-test.sh
-      if: branch != master
       env:
         - STATE_DIR=$HOME/img

--- a/Makefile
+++ b/Makefile
@@ -147,11 +147,15 @@ $(RUNCBUILDDIR)/runc: $(RUNCBUILDDIR)
 	GOPATH=$(BUILDDIR) $(MAKE) -C "$(RUNCBUILDDIR)" static BUILDTAGS="seccomp apparmor"
 
 internal/binutils/runc.go: $(RUNCBUILDDIR)/runc
-	go-bindata -pkg binutils -prefix "$(RUNCBUILDDIR)" -o $(CURDIR)/internal/binutils/runc.go $(RUNCBUILDDIR)/runc
+	go-bindata -tags \!noembed -pkg binutils -prefix "$(RUNCBUILDDIR)" -o $(CURDIR)/internal/binutils/runc.go $(RUNCBUILDDIR)/runc
 	gofmt -s -w $(CURDIR)/internal/binutils/runc.go
 
 .PHONY: runc
+ifneq (,$(findstring noembed,$(BUILDTAGS)))
+runc: ## No-op when not embedding runc.
+else
 runc: internal/binutils/runc.go ## Builds runc locally so it can be embedded in the resulting binary.
+endif
 
 .PHONY: clean
 clean: ## Cleanup any build binaries or packages

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ On Ubuntu, `newuidmap` is provided by the `uidmap` package.
 `runc` will be installed on start from an embedded binary if it is not already
 available locally.
 
+If you would like to disable the embedded runc you can use `BUILDTAGS="seccomp
+noembed"` while building from source with `make`. Or the environment variable
+`IMG_DISABLE_EMBEDDED_RUNC=1` on execution of the `img` binary.
+
 NOTE: These steps work only for Linux. Compile and run in a container 
 (explained below) if you're on Windows or MacOS.
 
@@ -107,6 +111,9 @@ $ git clone https://github.com/genuinetools/img $GOPATH/src/github.com/genuineto
 $ cd !$
 $ make
 $ sudo make install
+
+# For packagers if you would like to disable the embedded `runc`, please use:
+$ make BUILDTAGS="seccomp noembed"
 ```
 
 #### Running with Docker

--- a/contrib/e2e-dockerfiles-build-test.sh
+++ b/contrib/e2e-dockerfiles-build-test.sh
@@ -4,7 +4,7 @@ set -o pipefail
 
 SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 REPO_URL="${REPO_URL:-r.j3ss.co}"
-JOBS=${JOBS:-2}
+JOBS=${JOBS:-1}
 
 ERRORS="$(pwd)/errors"
 
@@ -58,7 +58,7 @@ main(){
 
 	# find the dockerfiles
 	IFS=$'\n'
-	files=( $(find -L . -iname '*Dockerfile' | sed 's|./||' | sort) )
+	files=( $(find -L . -iname '*Dockerfile' | sed 's|./||' | sort -R --random-source=/dev/urandom | head -n 5) )
 	unset IFS
 
 	# build all dockerfiles

--- a/internal/binutils/binutils.go
+++ b/internal/binutils/binutils.go
@@ -2,11 +2,7 @@ package binutils
 
 import (
 	"context"
-	"fmt"
-	"io/ioutil"
-	"os"
 	"os/exec"
-	"path/filepath"
 
 	librunc "github.com/containerd/go-runc"
 )
@@ -25,30 +21,4 @@ func RuncBinaryExists() bool {
 
 	// Return true when there is no error.
 	return err == nil
-}
-
-// InstallRuncBinary installs the embedded runc binary to the host.
-// It installs the binary to a temporary file and then updates the PATH so it
-// can be sourced throughout the execution of the program.
-func InstallRuncBinary() (string, error) {
-	data, err := Asset("runc")
-	if err != nil {
-		return "", fmt.Errorf("retrieving runc binary asset data failed: %v", err)
-	}
-
-	// Create a new temporary directory to house the binary.
-	dir, err := ioutil.TempDir("", "img-runc")
-	if err != nil {
-		return dir, fmt.Errorf("creating a temporary directory failed: %v", err)
-	}
-
-	f := filepath.Join(dir, "runc")
-	if err := ioutil.WriteFile(f, data, 0755); err != nil {
-		return dir, fmt.Errorf("writing to temporary file for runc binary failed: %v", err)
-	}
-
-	// Set the environment variable for PATH to the current plus the path to the
-	// embedded binary.
-	path := os.Getenv("PATH")
-	return dir, os.Setenv("PATH", dir+":"+path)
 }

--- a/internal/binutils/install.go
+++ b/internal/binutils/install.go
@@ -1,0 +1,36 @@
+// +build !noembed
+
+package binutils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// InstallRuncBinary installs the embedded runc binary to the host.
+// It installs the binary to a temporary file and then updates the PATH so it
+// can be sourced throughout the execution of the program.
+func InstallRuncBinary() (string, error) {
+	data, err := Asset("runc")
+	if err != nil {
+		return "", fmt.Errorf("retrieving runc binary asset data failed: %v", err)
+	}
+
+	// Create a new temporary directory to house the binary.
+	dir, err := ioutil.TempDir("", "img-runc")
+	if err != nil {
+		return dir, fmt.Errorf("creating a temporary directory failed: %v", err)
+	}
+
+	f := filepath.Join(dir, "runc")
+	if err := ioutil.WriteFile(f, data, 0755); err != nil {
+		return dir, fmt.Errorf("writing to temporary file for runc binary failed: %v", err)
+	}
+
+	// Set the environment variable for PATH to the current plus the path to the
+	// embedded binary.
+	path := os.Getenv("PATH")
+	return dir, os.Setenv("PATH", dir+":"+path)
+}

--- a/internal/binutils/install_noembed.go
+++ b/internal/binutils/install_noembed.go
@@ -1,0 +1,10 @@
+// +build noembed
+
+package binutils
+
+import "errors"
+
+// InstallRuncBinary when non-embedded errors out telling the user to install runc.
+func InstallRuncBinary() (string, error) {
+	return "", errors.New("please install `runc`")
+}

--- a/main.go
+++ b/main.go
@@ -134,6 +134,10 @@ func main() {
 			// If the command requires runc and we do not have it installed,
 			// install it from the embedded asset.
 			if command.RequiresRunc() && !binutils.RuncBinaryExists() {
+				if len(os.Getenv("IMG_DISABLE_EMBEDDED_RUNC")) > 0 {
+					// Fail early with the error to install runc.
+					logrus.Fatal("please install `runc`")
+				}
 				runcDir, err := binutils.InstallRuncBinary()
 				if err != nil {
 					os.RemoveAll(runcDir)


### PR DESCRIPTION
works like so:
```
$ make install BUILDTAGS="seccomp noembed"
+ install
go install -a -tags "seccomp noembed" -ldflags "-w -X github.com/genuinetools/img/version.GITCOMMIT=455629ae-dirty -X github.com/genuinetools/img/version.VERSION=v0.4.1" .

$ img build -t thing .
FATA[0000] Installing embedded runc binary failed: please install `runc`
```

closes #107

cc @AkihiroSuda 