### PR TITLE
Remove "Via Go" from README, since it doesn't work (#119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,6 @@ $ sudo chmod a+x /usr/local/bin/img
 $ echo "img installed!"
 ```
 
-#### Via Go
-
-```bash
-$ go get github.com/genuinetools/img
-```
-
 #### From Source
 
 ```bash


### PR DESCRIPTION
Per #119, it's not possible to build with `go get`. Take that out of the README.md file so it's not tempting.

Closes #134 