### PR TITLE
 Do not fail on basic auth in login.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -264,7 +264,7 @@
   branch = "master"
   name = "github.com/genuinetools/reg"
   packages = ["registry"]
-  revision = "74603b6d47a08e9f347442a7f787acbb70bf4883"
+  revision = "65b2c0329da5b239a259f309a7ed8506be1508f6"
 
 [[projects]]
   name = "github.com/godbus/dbus"

--- a/login.go
+++ b/login.go
@@ -90,7 +90,7 @@ func (cmd *loginCommand) Run(args []string) error {
 		return fmt.Errorf("creating registry client failed: %v", err)
 	}
 	token, err := r.Token(r.URL)
-	if err != nil {
+	if err != nil && err != registryapi.ErrBasicAuth {
 		return fmt.Errorf("getting registry token failed: %v", err)
 	}
 

--- a/vendor/github.com/genuinetools/reg/registry/authchallenge.go
+++ b/vendor/github.com/genuinetools/reg/registry/authchallenge.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -12,6 +13,9 @@ var (
 	bearerRegex = regexp.MustCompile(
 		`^\s*Bearer\s+(.*)$`)
 	basicRegex = regexp.MustCompile(`^\s*Basic\s+.*$`)
+
+	// ErrBasicAuth indicates that the repository requires basic rather than token authentication.
+	ErrBasicAuth = errors.New("basic auth required")
 )
 
 func parseAuthHeader(header http.Header) (*authService, error) {
@@ -25,7 +29,7 @@ func parseAuthHeader(header http.Header) (*authService, error) {
 
 func parseChallenge(challengeHeader string) (*authService, error) {
 	if basicRegex.MatchString(challengeHeader) {
-		return nil, fmt.Errorf("basic auth required")
+		return nil, ErrBasicAuth
 	}
 
 	match := bearerRegex.FindAllStringSubmatch(challengeHeader, -1)

--- a/vendor/github.com/genuinetools/reg/registry/authchallenge_test.go
+++ b/vendor/github.com/genuinetools/reg/registry/authchallenge_test.go
@@ -47,6 +47,14 @@ func TestParseChallenge(t *testing.T) {
 				scope:   []string{"repository:chrome:pull"},
 			},
 		},
+		{
+			header:      `Basic realm="https://r.j3ss.co/auth",service="Docker registry"`,
+			errorString: "basic auth required",
+		},
+		{
+			header:      `Basic realm="Registry Realm",service="Docker registry"`,
+			errorString: "basic auth required",
+		},
 	}
 
 	for _, tc := range challengeHeaderCases {
@@ -54,7 +62,7 @@ func TestParseChallenge(t *testing.T) {
 		if err != nil && !strings.Contains(err.Error(), tc.errorString) {
 			t.Fatalf("expected error to contain %v,  got %s", tc.errorString, err)
 		}
-		if !tc.value.equalTo(val) {
+		if err == nil && !tc.value.equalTo(val) {
 			t.Fatalf("got %v, expected %v", val, tc.value)
 		}
 

--- a/vendor/github.com/genuinetools/reg/registry/tokentransport_test.go
+++ b/vendor/github.com/genuinetools/reg/registry/tokentransport_test.go
@@ -1,0 +1,38 @@
+package registry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+)
+
+func TestErrBasicAuth(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.Header().Set("www-authenticate", `Basic realm="Registry Realm",service="Docker registry"`)
+			w.WriteHeader(http.StatusUnauthorized)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	authConfig := types.AuthConfig{
+		Username:      "j3ss",
+		Password:      "ss3j",
+		ServerAddress: ts.URL,
+	}
+	r, err := New(authConfig, Opt{Insecure: true, Debug: true})
+	if err != nil {
+		t.Fatalf("expected no error creating client, got %v", err)
+	}
+	token, err := r.Token(ts.URL)
+	if err != ErrBasicAuth {
+		t.Fatalf("expected ErrBasicAuth getting token, got %v", err)
+	}
+	if token != "" {
+		t.Fatalf("expected empty token, got %v", err)
+	}
+}


### PR DESCRIPTION
This PR is structured as two commits:
- The first commit pulls in a new version of genuinetools/reg in order to pick up some recent changes to basic auth detection
- The second commit uses the changes pulled in from the first to detect registries that require basic auth (e.g. ECR) s.t. `img login` does not fail on these registries

I've tested these changes manually with an ECR repository and verified that pushes and pulls operate as expected. This addresses part of #128.