### PR TITLE
Updated Arch installation instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,13 @@ $ make BUILDTAGS="seccomp noembed"
 There is an [AUR build](https://aur.archlinux.org/packages/img/).
 
 ```console
-$ sudo pacman -S img
+# Use whichever AUR helper you prefer
+$ yay -S img
+
+# Or build from the source PKGBUILD
+$ git clone https://aur.archlinux.org/packages/img.git
+$ cd img
+$ makepkg -si
 ```
 
 #### Gentoo


### PR DESCRIPTION
Came across Arch install instructions and noticed it mentions pacman, which won't install AUR packages.

I included Arch build instructions for AUR helper of choice and also building with the PKGBUILD. 



Looking forward to digging into more of this, this project has huge promise for unprivileged Docker in Docker builds and I have already suggested to my DevOps evangelists to follow its development. :+1: 