### PR TITLE
Fix IMG_SHA256 to match v0.5.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The below instructions mirror that of the [v0.5.0 release page](https://github.c
 
 ```console
 # Export the sha256sum for verification.
-$ export IMG_SHA256="2625bc82af21b2bcb1aef9281cbfc76ea99f80985209ad5945c06b426da4e0b3"
+$ export IMG_SHA256="c7db856ef0472df30115c3f76180a1c001d22406e22dbae60a648cc0afee15d3"
 
 # Download and check the sha256sum.
 $ curl -fSL "https://github.com/genuinetools/img/releases/download/v0.5.0/img-linux-amd64" -o "/usr/local/bin/img" \


### PR DESCRIPTION
Fix IMG_SHA256 to match v0.5.0 release
From https://github.com/genuinetools/img/releases/tag/v0.5.0