### PR TITLE
check for newuidmap before reexec

### DIFF
--- a/reexec.go
+++ b/reexec.go
@@ -33,6 +33,11 @@ func reexec() {
 			}
 		}()
 
+		// If newuidmap is not present re-exec will fail
+		if _, err := exec.LookPath("newuidmap"); err != nil {
+			logrus.Fatalf("newuidmap not found (install uidmap package?): %v", err)
+		}
+
 		// Initialize and re-exec with our unshare.
 		cmd := exec.Command("/proc/self/exe", os.Args[1:]...)
 		cmd.Env = append(os.Environ(), "IMG_DO_UNSHARE=1")


### PR DESCRIPTION
Without this check img subcommands will fail:

nsenter: failed to execv: No such file or directory
nsenter: failed to sync with parent: SYNC_USERMAP_ACK: got 255: Success
nsenter: failed to use newuidmap: Success

With it, you get this instead:

FATA[0000] newuidmap not found (install uidmap package?): exec: "newuidmap": executable file not found in $PATH·

