### PR TITLE
Dockerfile, shadow: use the branch name instead of the commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN make static && mv img /usr/bin/img
 #    So we need to apply https://github.com/shadow-maint/shadow/pull/132 .
 FROM alpine:3.8 AS idmap
 RUN apk add --no-cache autoconf automake build-base byacc gettext gettext-dev gcc git libcap-dev libtool libxslt
-RUN ( git clone https://github.com/giuseppe/shadow.git /shadow && cd /shadow && git checkout 336cead97d87be6c4828521f50a992e76a17e442 )
+RUN ( git clone -b no-cap-sys-admin https://github.com/giuseppe/shadow.git /shadow && cd /shadow )
 WORKDIR /shadow
 RUN ./autogen.sh --disable-nls --disable-man --without-audit --without-selinux --without-acl --without-attr --without-tcb --without-nscd \
   && make \


### PR DESCRIPTION
I've done few changes and pushed a new version so the old commit
doesn't exist anymore.  Since I am probably going to make more
changes, it is safer to use the branch.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>