### PR TITLE
Travis: Use xenial build dist + tiny cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jobs:
     - stage: Build Release
       script:
         - make release
+      before_deploy:
         - echo "Deploying to GitHub releases ..."
       deploy:
         provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 language: go
-sudo: true
+dist: xenial
 notifications:
   email: true
 go:
   - 1.11.x
+addons:
+  apt:
+    packages:
+      - libseccomp-dev
+      - parallel
+      - uidmap
 before_install:
   - go get golang.org/x/lint/golint
   - go get honnef.co/go/tools/cmd/staticcheck
   - go get -u github.com/jteeuwen/go-bindata/...
-  - echo "deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/backports.list
-  - sudo apt update
-  - sudo apt install -y --no-install-recommends -t trusty-backports libseccomp-dev parallel uidmap
   - curl -sSL -o runc https://misc.j3ss.co/tmp/runc && chmod +x runc && sudo mv runc /usr/bin/runc
 jobs:
   include:


### PR DESCRIPTION
Hi 👋, I was checking out `img` and it seems cool so I thought I'd try make a super minor contribution.

This updates Travis to use the Xenial environment, which Travis reckons is now ["ready for a wider audience"](https://blog.travis-ci.com/2018-11-08-xenial-release). This makes using `trusty-backports` unnecessary.

Other _very_ minor changes:
* `sudo: true` is now unnecessary. All Travis builds have sudo now.
* Moved the deploy debug message to `before_deploy` which only gets run if `deploy` will be. Alternatively, could skip the build stage completely if there is no tag, but that'd mean `make release` would be run much less often.