### PR TITLE
Added apk repository url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $ make BUILDTAGS="seccomp noembed"
 There is an [APKBUILD](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/img).
 
 ```console
-$ apk add img
+$ apk add img --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 ```
 
 #### Arch Linux


### PR DESCRIPTION
The the alpine package is in the edge/testing repository, so running:
```console
apk add img
```
won't work by default, hence the update to:
```console
apk add img --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
```