### PR TITLE
Use credential-helper creds, bypass prompt.

### DIFF
--- a/login.go
+++ b/login.go
@@ -144,7 +144,7 @@ func configureAuth(flUser, flPassword, serverAddress string) (*configfile.Config
 		return dcfg, authConfig, fmt.Errorf("getting auth config for %s failed: %v", serverAddress, err)
 	}
 
-	// A credential helper is being used to populate authentication
+	// A credential helper is being used to populate authentication.
 	if dcfg.CredentialHelpers[serverAddress] != "" && authConfig.Password != "" && authConfig.Username != "" && flUser == "" && flPassword == "" {
 		return dcfg, authConfig, nil
 	}

--- a/login.go
+++ b/login.go
@@ -139,18 +139,22 @@ func configureAuth(flUser, flPassword, serverAddress string) (*configfile.Config
 	if err != nil {
 		return dcfg, types.AuthConfig{}, fmt.Errorf("loading config file failed: %v", err)
 	}
+
 	authConfig, err := dcfg.GetAuthConfig(serverAddress)
 	if err != nil {
 		return dcfg, authConfig, fmt.Errorf("getting auth config for %s failed: %v", serverAddress, err)
+	}
+
+	// A credential helper is being used to populate authentication
+	if dcfg.CredentialHelpers[serverAddress] != "" && authConfig.Password != "" && authConfig.Username != "" && flUser == "" && flPassword == "" {
+		return dcfg, authConfig, nil
 	}
 
 	_, isTerminal := term.GetFdInfo(os.Stdin)
 	if flPassword == "" && !isTerminal {
 		return dcfg, authConfig, errors.New("cannot perform an interactive login from a non TTY device")
 	}
-
 	authConfig.Username = strings.TrimSpace(authConfig.Username)
-
 	if flUser = strings.TrimSpace(flUser); flUser == "" {
 		if serverAddress == defaultDockerRegistry {
 			// if this is a default registry (docker hub), then display the following message.

--- a/login.go
+++ b/login.go
@@ -139,7 +139,6 @@ func configureAuth(flUser, flPassword, serverAddress string) (*configfile.Config
 	if err != nil {
 		return dcfg, types.AuthConfig{}, fmt.Errorf("loading config file failed: %v", err)
 	}
-
 	authConfig, err := dcfg.GetAuthConfig(serverAddress)
 	if err != nil {
 		return dcfg, authConfig, fmt.Errorf("getting auth config for %s failed: %v", serverAddress, err)
@@ -154,7 +153,9 @@ func configureAuth(flUser, flPassword, serverAddress string) (*configfile.Config
 	if flPassword == "" && !isTerminal {
 		return dcfg, authConfig, errors.New("cannot perform an interactive login from a non TTY device")
 	}
+
 	authConfig.Username = strings.TrimSpace(authConfig.Username)
+
 	if flUser = strings.TrimSpace(flUser); flUser == "" {
 		if serverAddress == defaultDockerRegistry {
 			// if this is a default registry (docker hub), then display the following message.

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 	flags := cmd.PersistentFlags()
 	flags.BoolVarP(&debug, "debug", "d", false, "enable debug logging")
 	flags.StringVarP(&backend, "backend", "b", defaultBackend, fmt.Sprintf("backend for snapshots (%v)", validBackends))
-	flags.StringVarP(&stateDir, "state", "s", defaultStateDir, fmt.Sprintf("directory to hold the global state"))
+	flags.StringVarP(&stateDir, "state", "s", defaultStateDir, "directory to hold the global state")
 
 	// Set the before function.
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
I was looking at what it would take to solve respecting the helpers for GCR and ECR for https://github.com/genuinetools/img/issues/128 especially within the context of an automated build environment.

Turns out it's basically already implemented, we just need to use both the user (or access token) and secret from the authConfig that is already being populated by the helper.

This change bypasses the username and password prompt if none are passed in, and we already get them from the credential helper-- automating gcr and ecr creds helper authentication for `img`

Tested against my own private repos in `docker-credential-gcloud` (via `gcloud auth` and `docker-credential-ecr`).