### PR TITLE
Add osusergo build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PKG := github.com/genuinetools/$(NAME)
 CGO_ENABLED := 1
 
 # Set any default go build tags
-BUILDTAGS ?= seccomp
+BUILDTAGS ?= seccomp osusergo
 
 include basic.mk
 


### PR DESCRIPTION
This enables a Go-native os/user which should make binaries built on
Ubuntu Bionic (in this case, via travis-ci.org) work on other Linuxes
with different syscall ABIs.

Fixes a segfault when cgo is looking up a user.