### PR TITLE
Login to Azure container Registry Fails

### DIFF
--- a/login.go
+++ b/login.go
@@ -104,7 +104,7 @@ func (cmd *loginCommand) Run(args []string) error {
 	}
 
 	// Attempt to login to the registry.
-	r, err := registryapi.New(cliconfigtypes2dockerapitypes(authConfig), registryapi.Opt{Debug: debug})
+	r, err := registryapi.New(cliconfigtypes2dockerapitypes(authConfig), registryapi.Opt{Debug: debug, SkipPing: true})
 	if err != nil {
 		return fmt.Errorf("creating registry client failed: %v", err)
 	}


### PR DESCRIPTION
Img cannot be used to login to azure container registry. This is due to Pinging registry without auth credentials causing it to fail. So removed pinging altogether. 

PS: Ideally, the fix should be in reg the library but there is no release for nearly a year. Until we get that change in reg, adding a workaround here to fix this. 