### PR TITLE
Changing the long form for username in img login to be username instead of user

### DIFF
--- a/login.go
+++ b/login.go
@@ -42,7 +42,7 @@ func newLoginCommand() *cobra.Command {
 
 	fs := cmd.Flags()
 
-	fs.StringVarP(&login.user, "user", "u", "", "Username")
+	fs.StringVarP(&login.user, "username", "u", "", "Username")
 	fs.StringVarP(&login.password, "password", "p", "", "Password")
 	fs.BoolVar(&login.passwordStdin, "password-stdin", false, "Take the password from stdin")
 


### PR DESCRIPTION
For img login the username can be passed via -u or --user but --user is not compatible with docker cli. So changing it to --username to be same as docker cli. It was --username before the last release. Reverting back to same. 