### PR TITLE
Cache import/export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,16 +239,18 @@ build -  Build an image from a Dockerfile
 Usage: img build [OPTIONS] PATH
 
 Flags:
-      --build-arg list   Set build-time variables
-  -f, --file string      Name of the Dockerfile (Default is 'PATH/Dockerfile')
-  -h, --help             help for build
-      --label list       Set metadata for an image
-      --no-cache         Do not use cache when building the image
-      --no-console       Use non-console progress UI
-  -o, --output string    BuildKit output specification (e.g. type=tar,dest=build.tar)
-      --platform list    Set platforms for which the image should be built
-  -t, --tag list         Name and optionally a tag in the 'name:tag' format
-      --target string    Set the target build stage to build
+      --build-arg list    Set build-time variables
+      --cache-from list   Buildkit import-cache or Buildx cache-from specification
+      --cache-to list     Buildx cache-to specification
+  -f, --file string       Name of the Dockerfile (Default is 'PATH/Dockerfile')
+  -h, --help              help for build
+      --label list        Set metadata for an image
+      --no-cache          Do not use cache when building the image
+      --no-console        Use non-console progress UI
+  -o, --output string     BuildKit output specification (e.g. type=tar,dest=build.tar)
+      --platform list     Set platforms for which the image should be built
+  -t, --tag list          Name and optionally a tag in the 'name:tag' format
+      --target string     Set the target build stage to build
 
 Global Flags:
   -b, --backend string   backend for snapshots ([auto native overlayfs]) (default "auto")

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/genuinetools/reg v0.16.0
 	github.com/mitchellh/hashstructure v1.0.0 // indirect
-	github.com/moby/buildkit v0.7.1
+	github.com/moby/buildkit v0.7.2
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/opencontainers/runc v1.0.0-rc9.0.20200221051241-688cf6d43cc4
 	github.com/opentracing-contrib/go-stdlib v0.0.0-20180702182724-07a764486eb1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/moby/buildkit v0.7.1 h1:aPnJdFwfTVuV/+MpOiBu0rTWi0FnRoUYX/WI+8ZJQeU=
 github.com/moby/buildkit v0.7.1/go.mod h1:D3DN/Nl4DyMH1LkwpRUJuoghqdigdXd1A6HXt5aZS40=
+github.com/moby/buildkit v0.7.2 h1:wp4R0QMXSqwjTJKhhWlJNOCSQ/OVPnsCf3N8rs09+vQ=
+github.com/moby/buildkit v0.7.2/go.mod h1:D3DN/Nl4DyMH1LkwpRUJuoghqdigdXd1A6HXt5aZS40=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c h1:nXxl5PrvVm2L/wCy8dQu6DMTwH4oIuGN8GJDAlqDdVE=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=

--- a/vendor/github.com/moby/buildkit/cache/contenthash/filehash.go
+++ b/vendor/github.com/moby/buildkit/cache/contenthash/filehash.go
@@ -40,6 +40,9 @@ func NewFileHash(path string, fi os.FileInfo) (hash.Hash, error) {
 }
 
 func NewFromStat(stat *fstypes.Stat) (hash.Hash, error) {
+	// Clear the socket bit since archive/tar.FileInfoHeader does not handle it
+	stat.Mode &^= uint32(os.ModeSocket)
+
 	fi := &statInfo{stat}
 	hdr, err := tar.FileInfoHeader(fi, stat.Linkname)
 	if err != nil {

--- a/vendor/github.com/moby/buildkit/cache/contenthash/tarsum.go
+++ b/vendor/github.com/moby/buildkit/cache/contenthash/tarsum.go
@@ -39,7 +39,7 @@ func v1TarHeaderSelect(h *tar.Header) (orderedHeaders [][2]string) {
 	// Get extended attributes.
 	xAttrKeys := make([]string, len(h.Xattrs))
 	for k := range h.Xattrs {
-		if !strings.HasPrefix(k, "security.") && !strings.HasPrefix(k, "system.") {
+		if k == "security.capability" || !strings.HasPrefix(k, "security.") && !strings.HasPrefix(k, "system.") {
 			xAttrKeys = append(xAttrKeys, k)
 		}
 	}

--- a/vendor/github.com/moby/buildkit/cache/refs.go
+++ b/vendor/github.com/moby/buildkit/cache/refs.go
@@ -180,7 +180,10 @@ func (cr *cacheRecord) Size(ctx context.Context) (int64, error) {
 		cr.mu.Unlock()
 		return usage.Size, nil
 	})
-	return s.(int64), err
+	if err != nil {
+		return 0, err
+	}
+	return s.(int64), nil
 }
 
 func (cr *cacheRecord) Parent() ImmutableRef {

--- a/vendor/github.com/moby/buildkit/cache/remotecache/inline/inline.go
+++ b/vendor/github.com/moby/buildkit/cache/remotecache/inline/inline.go
@@ -72,7 +72,7 @@ func (ce *exporter) ExportForLayers(layers []digest.Digest) ([]byte, error) {
 		return nil, nil
 	}
 
-	cache := map[digest.Digest]int{}
+	cache := map[int]int{}
 
 	// reorder layers based on the order in the image
 	for i, r := range cfg.Records {
@@ -93,14 +93,14 @@ func (ce *exporter) ExportForLayers(layers []digest.Digest) ([]byte, error) {
 	return dt, nil
 }
 
-func getSortedLayerIndex(idx int, layers []v1.CacheLayer, cache map[digest.Digest]int) int {
+func getSortedLayerIndex(idx int, layers []v1.CacheLayer, cache map[int]int) int {
 	if idx == -1 {
 		return -1
 	}
 	l := layers[idx]
-	if i, ok := cache[l.Blob]; ok {
+	if i, ok := cache[idx]; ok {
 		return i
 	}
-	cache[l.Blob] = getSortedLayerIndex(l.ParentIndex, layers, cache) + 1
-	return cache[l.Blob]
+	cache[idx] = getSortedLayerIndex(l.ParentIndex, layers, cache) + 1
+	return cache[idx]
 }

--- a/vendor/github.com/moby/buildkit/cache/remotecache/local/local.go
+++ b/vendor/github.com/moby/buildkit/cache/remotecache/local/local.go
@@ -1,0 +1,83 @@
+package local
+
+import (
+	"context"
+	"time"
+
+	"github.com/containerd/containerd/content"
+	"github.com/moby/buildkit/cache/remotecache"
+	"github.com/moby/buildkit/session"
+	sessioncontent "github.com/moby/buildkit/session/content"
+	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+const (
+	attrDigest           = "digest"
+	attrSrc              = "src"
+	attrDest             = "dest"
+	contentStoreIDPrefix = "local:"
+)
+
+// ResolveCacheExporterFunc for "local" cache exporter.
+func ResolveCacheExporterFunc(sm *session.Manager) remotecache.ResolveCacheExporterFunc {
+	return func(ctx context.Context, attrs map[string]string) (remotecache.Exporter, error) {
+		store := attrs[attrDest]
+		if store == "" {
+			return nil, errors.New("local cache exporter requires dest")
+		}
+		csID := contentStoreIDPrefix + store
+		cs, err := getContentStore(ctx, sm, csID)
+		if err != nil {
+			return nil, err
+		}
+		return remotecache.NewExporter(cs), nil
+	}
+}
+
+// ResolveCacheImporterFunc for "local" cache importer.
+func ResolveCacheImporterFunc(sm *session.Manager) remotecache.ResolveCacheImporterFunc {
+	return func(ctx context.Context, attrs map[string]string) (remotecache.Importer, specs.Descriptor, error) {
+		dgstStr := attrs[attrDigest]
+		if dgstStr == "" {
+			return nil, specs.Descriptor{}, errors.New("local cache importer requires explicit digest")
+		}
+		dgst := digest.Digest(dgstStr)
+		store := attrs[attrSrc]
+		if store == "" {
+			return nil, specs.Descriptor{}, errors.New("local cache importer requires src")
+		}
+		csID := contentStoreIDPrefix + store
+		cs, err := getContentStore(ctx, sm, csID)
+		if err != nil {
+			return nil, specs.Descriptor{}, err
+		}
+		info, err := cs.Info(ctx, dgst)
+		if err != nil {
+			return nil, specs.Descriptor{}, err
+		}
+		desc := specs.Descriptor{
+			// MediaType is typically MediaTypeDockerSchema2ManifestList,
+			// but we leave it empty until we get correct support for local index.json
+			Digest: dgst,
+			Size:   info.Size,
+		}
+		return remotecache.NewImporter(cs), desc, nil
+	}
+}
+
+func getContentStore(ctx context.Context, sm *session.Manager, storeID string) (content.Store, error) {
+	sessionID := session.FromContext(ctx)
+	if sessionID == "" {
+		return nil, errors.New("local cache exporter/importer requires session")
+	}
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	caller, err := sm.Get(timeoutCtx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	return sessioncontent.NewCallerStore(caller, storeID), nil
+}

--- a/vendor/github.com/moby/buildkit/cache/remotecache/v1/cachestorage.go
+++ b/vendor/github.com/moby/buildkit/cache/remotecache/v1/cachestorage.go
@@ -220,6 +220,7 @@ func (cs *cacheResultStorage) LoadWithParents(ctx context.Context, res solver.Ca
 
 	m := map[string]solver.Result{}
 
+	visited := make(map[*item]struct{})
 	if err := v.walkAllResults(func(i *item) error {
 		if i.result == nil {
 			return nil
@@ -236,7 +237,7 @@ func (cs *cacheResultStorage) LoadWithParents(ctx context.Context, res solver.Ca
 			m[id] = worker.NewWorkerRefResult(ref, cs.w)
 		}
 		return nil
-	}); err != nil {
+	}, visited); err != nil {
 		for _, v := range m {
 			v.Release(context.TODO())
 		}

--- a/vendor/github.com/moby/buildkit/cache/remotecache/v1/chains.go
+++ b/vendor/github.com/moby/buildkit/cache/remotecache/v1/chains.go
@@ -128,13 +128,17 @@ func (c *item) LinkFrom(rec solver.CacheExporterRecord, index int, selector stri
 	c.links[index][link{src: src, selector: selector}] = struct{}{}
 }
 
-func (c *item) walkAllResults(fn func(i *item) error) error {
+func (c *item) walkAllResults(fn func(i *item) error, visited map[*item]struct{}) error {
+	if _, ok := visited[c]; ok {
+		return nil
+	}
+	visited[c] = struct{}{}
 	if err := fn(c); err != nil {
 		return err
 	}
 	for _, links := range c.links {
 		for l := range links {
-			if err := l.src.walkAllResults(fn); err != nil {
+			if err := l.src.walkAllResults(fn, visited); err != nil {
 				return err
 			}
 		}

--- a/vendor/github.com/moby/buildkit/frontend/gateway/gateway.go
+++ b/vendor/github.com/moby/buildkit/frontend/gateway/gateway.go
@@ -472,7 +472,9 @@ func (lbf *llbBridgeForwarder) Solve(ctx context.Context, req *pb.SolveRequest) 
 		return nil, errors.Errorf("solve did not return default result")
 	}
 
-	pbRes := &pb.Result{}
+	pbRes := &pb.Result{
+		Metadata: res.Metadata,
+	}
 	var defaultID string
 
 	lbf.mu.Lock()

--- a/vendor/github.com/moby/buildkit/frontend/gateway/pb/caps.go
+++ b/vendor/github.com/moby/buildkit/frontend/gateway/pb/caps.go
@@ -32,6 +32,9 @@ const (
 	// CapFrontendInputs is a capability to request frontend inputs from the
 	// LLBBridge GRPC server.
 	CapFrontendInputs apicaps.CapID = "frontend.inputs"
+
+	// CapGatewaySolveMetadata can be used to check if solve calls from gateway reliably return metadata
+	CapGatewaySolveMetadata apicaps.CapID = "gateway.solve.metadata"
 )
 
 func init() {
@@ -123,6 +126,13 @@ func init() {
 	Caps.Init(apicaps.Cap{
 		ID:      CapFrontendInputs,
 		Name:    "frontend inputs",
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapGatewaySolveMetadata,
+		Name:    "gateway metadata",
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})

--- a/vendor/github.com/moby/buildkit/session/filesync/filesync.go
+++ b/vendor/github.com/moby/buildkit/session/filesync/filesync.go
@@ -255,7 +255,7 @@ func (sp *fsSyncTarget) Register(server *grpc.Server) {
 	RegisterFileSendServer(server, sp)
 }
 
-func (sp *fsSyncTarget) DiffCopy(stream FileSend_DiffCopyServer) error {
+func (sp *fsSyncTarget) DiffCopy(stream FileSend_DiffCopyServer) (err error) {
 	if sp.outdir != "" {
 		return syncTargetDiffCopy(stream, sp.outdir)
 	}
@@ -277,7 +277,12 @@ func (sp *fsSyncTarget) DiffCopy(stream FileSend_DiffCopyServer) error {
 	if wc == nil {
 		return status.Errorf(codes.AlreadyExists, "target already exists")
 	}
-	defer wc.Close()
+	defer func() {
+		err1 := wc.Close()
+		if err != nil {
+			err = err1
+		}
+	}()
 	return writeTargetFile(stream, wc)
 }
 

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/file/backend.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/file/backend.go
@@ -34,16 +34,17 @@ func mapUserToChowner(user *copy.User, idmap *idtools.IdentityMapping) (copy.Cho
 					return nil, nil
 				}
 				old = &copy.User{} // root
-			}
-			if idmap != nil {
-				identity, err := idmap.ToHost(idtools.Identity{
-					UID: old.Uid,
-					GID: old.Gid,
-				})
-				if err != nil {
-					return nil, err
+				// non-nil old is already mapped
+				if idmap != nil {
+					identity, err := idmap.ToHost(idtools.Identity{
+						UID: old.Uid,
+						GID: old.Gid,
+					})
+					if err != nil {
+						return nil, err
+					}
+					return &copy.User{Uid: identity.UID, Gid: identity.GID}, nil
 				}
-				return &copy.User{Uid: identity.UID, Gid: identity.GID}, nil
 			}
 			return old, nil
 		}, nil

--- a/vendor/github.com/moby/buildkit/util/contentutil/pusher.go
+++ b/vendor/github.com/moby/buildkit/util/contentutil/pusher.go
@@ -2,21 +2,34 @@ package contentutil
 
 import (
 	"context"
+	"runtime"
+	"sync"
+	"time"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/remotes"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 
 func FromPusher(p remotes.Pusher) content.Ingester {
+	var mu sync.Mutex
+	c := sync.NewCond(&mu)
 	return &pushingIngester{
-		p: p,
+		mu:     &mu,
+		c:      c,
+		p:      p,
+		active: map[digest.Digest]struct{}{},
 	}
 }
 
 type pushingIngester struct {
 	p remotes.Pusher
+
+	mu     *sync.Mutex
+	c      *sync.Cond
+	active map[digest.Digest]struct{}
 }
 
 // Writer implements content.Ingester. desc.MediaType must be set for manifest blobs.
@@ -30,20 +43,55 @@ func (i *pushingIngester) Writer(ctx context.Context, opts ...content.WriterOpt)
 	if wOpts.Ref == "" {
 		return nil, errors.Wrap(errdefs.ErrInvalidArgument, "ref must not be empty")
 	}
+
+	st := time.Now()
+
+	i.mu.Lock()
+	for {
+		if time.Since(st) > time.Hour {
+			i.mu.Unlock()
+			return nil, errors.Wrapf(errdefs.ErrUnavailable, "ref %v locked", wOpts.Desc.Digest)
+		}
+		if _, ok := i.active[wOpts.Desc.Digest]; ok {
+			i.c.Wait()
+		} else {
+			break
+		}
+	}
+
+	i.active[wOpts.Desc.Digest] = struct{}{}
+	i.mu.Unlock()
+
+	var once sync.Once
+	release := func() {
+		once.Do(func() {
+			i.mu.Lock()
+			delete(i.active, wOpts.Desc.Digest)
+			i.c.Broadcast()
+			i.mu.Unlock()
+		})
+	}
+
 	// pusher requires desc.MediaType to determine the PUT URL, especially for manifest blobs.
 	contentWriter, err := i.p.Push(ctx, wOpts.Desc)
 	if err != nil {
+		release()
 		return nil, err
 	}
+	runtime.SetFinalizer(contentWriter, func(_ content.Writer) {
+		release()
+	})
 	return &writer{
 		Writer:           contentWriter,
 		contentWriterRef: wOpts.Ref,
+		release:          release,
 	}, nil
 }
 
 type writer struct {
 	content.Writer          // returned from pusher.Push
 	contentWriterRef string // ref passed for Writer()
+	release          func()
 }
 
 func (w *writer) Status() (content.Status, error) {
@@ -55,4 +103,20 @@ func (w *writer) Status() (content.Status, error) {
 		st.Ref = w.contentWriterRef
 	}
 	return st, nil
+}
+
+func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
+	err := w.Writer.Commit(ctx, size, expected, opts...)
+	if w.release != nil {
+		w.release()
+	}
+	return err
+}
+
+func (w *writer) Close() error {
+	err := w.Writer.Close()
+	if w.release != nil {
+		w.release()
+	}
+	return err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -208,7 +208,7 @@ github.com/konsorten/go-windows-terminal-sequences
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/mitchellh/hashstructure v1.0.0
 github.com/mitchellh/hashstructure
-# github.com/moby/buildkit v0.7.1
+# github.com/moby/buildkit v0.7.2
 github.com/moby/buildkit/api/services/control
 github.com/moby/buildkit/api/types
 github.com/moby/buildkit/cache
@@ -217,6 +217,7 @@ github.com/moby/buildkit/cache/contenthash
 github.com/moby/buildkit/cache/metadata
 github.com/moby/buildkit/cache/remotecache
 github.com/moby/buildkit/cache/remotecache/inline
+github.com/moby/buildkit/cache/remotecache/local
 github.com/moby/buildkit/cache/remotecache/registry
 github.com/moby/buildkit/cache/remotecache/v1
 github.com/moby/buildkit/cache/util


### PR DESCRIPTION
Added in support to utilize moby/buildkit `import-cache` and `export-cache` fields. Updated the README to include all the information about the new fields. Thanks to @Chippiewill for all the help that he did through his #279 PR, really made this addition a lot easier. This is to support #263 and all to add the ability to utilize more caching by being able to export some cache! Also thanks to #287, helped me understand more by providing a better explanation for the README.

Let me know if anything needs changes! First time committing in this repo, so please be kind especially if I made any silly mistakes.