### PR TITLE
Fix "prune" subcommand

### DIFF
--- a/client/prune.go
+++ b/client/prune.go
@@ -29,7 +29,7 @@ func (c *Client) Prune(ctx context.Context) ([]*controlapi.UsageRecord, error) {
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		// Call prune on the worker.
-		return w.Prune(ctx, ch)
+		return w.Prune(ctx, ch, client.PruneInfo{})
 	})
 
 	eg2, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
The current implementation of `img prune` does not actually remove any data. This changeset introduces an extra variadic argument to the `Prune` call, producing behavior equivalent to `buildctl prune` invoked without flags against a BuildKit daemon.

I think the issue and proposed fix become more clear with a look at the underlying implementation, which loops over the variadic
`PruneInfo` arguments and runs a prune operation based on options specified in each argument. With no arguments, it skips the loop and only runs the final garbage collection on the metadata store.

https://github.com/genuinetools/img/blob/d858ac71f93cc5084edd2ba2d425b90234cf2ead/vendor/github.com/moby/buildkit/cache/manager.go#L515-L520

I believe this resolves #153 and resolves #320.