### PR TITLE
pull: resolve the image config and set it on stored image

### DIFF
--- a/pull_test.go
+++ b/pull_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestPullFromDefaultRegistry(t *testing.T) {
@@ -27,5 +30,21 @@ func TestPullIsInListOutput(t *testing.T) {
 	out := run(t, "ls")
 	if !strings.Contains(out, "busybox:latest") {
 		t.Fatalf("expected busybox:latest in ls output, got: %s", out)
+	}
+}
+
+func TestPullRetainsConfig(t *testing.T) {
+	// Test an official image,
+	run(t, "pull", "alpine")
+
+	out := run(t, "inspect", "alpine")
+
+	var image ocispec.Image
+	if err := json.Unmarshal([]byte(out), &image); err != nil {
+		t.Fatalf("error decoding JSON: %s", err)
+	}
+
+	if len(image.Config.Cmd) == 0 {
+		t.Fatal("image config should be populated")
 	}
 }


### PR DESCRIPTION
Fixes #199 
Related to #234 

Previously `pull` would not properly retain the image configuration
which contains the entrypoint, working directory, user, and more. This
resulted in broken images if they were pulled then subsequently pushed.

This commit fetches the image config, which must be done separately, and
then ensures that the configuration is set on the exported image into
the local img state store.

Note that the config that is stored is an OCI image config and NOT a 
Docker config so the digest is still not equivalent but the encoding of this
is in BuildKit and not img so I think this is fine.