### PR TITLE
Add --insecure-registry to Pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,8 @@ pull -  Pull an image or a repository from a registry.
 Usage: img pull [OPTIONS] NAME[:TAG|@DIGEST]
 
 Flags:
-  -h, --help   help for pull
+  -h, --help                help for pull
+      --insecure-registry   Pull from insecure registry
 
 Global Flags:
   -b, --backend string   backend for snapshots ([auto native overlayfs fuse-overlayfs]) (default "auto")

--- a/client/pull.go
+++ b/client/pull.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Pull retrieves an image from a remote registry.
-func (c *Client) Pull(ctx context.Context, image string) (*ListedImage, error) {
+func (c *Client) Pull(ctx context.Context, image string, insecure bool) (*ListedImage, error) {
 	sm, err := c.getSessionManager()
 	if err != nil {
 		return nil, err
@@ -52,6 +52,11 @@ func (c *Client) Pull(ctx context.Context, image string) (*ListedImage, error) {
 		return nil, err
 	}
 
+	registriesHosts := opt.RegistryHosts
+	if insecure {
+		registriesHosts = configureRegistries("http")
+	}
+
 	// Create the source for the pull.
 	srcOpt := containerimage.SourceOpt{
 		Snapshotter:   opt.Snapshotter,
@@ -59,7 +64,7 @@ func (c *Client) Pull(ctx context.Context, image string) (*ListedImage, error) {
 		Applier:       opt.Applier,
 		CacheAccessor: cm,
 		ImageStore:    opt.ImageStore,
-		RegistryHosts: opt.RegistryHosts,
+		RegistryHosts: registriesHosts,
 		LeaseManager:  opt.LeaseManager,
 	}
 	src, err := containerimage.NewSource(srcOpt)

--- a/client/push.go
+++ b/client/push.go
@@ -3,11 +3,9 @@ package client
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/docker/distribution/reference"
 	"github.com/moby/buildkit/util/push"
-	"github.com/containerd/containerd/remotes/docker"
 )
 
 // Push sends an image to a remote registry.
@@ -39,31 +37,8 @@ func (c *Client) Push(ctx context.Context, image string, insecure bool) error {
 
 	registriesHosts := opt.RegistryHosts
 	if insecure {
-		registriesHosts = configurePushRegistries("http")
+		registriesHosts = configureRegistries("http")
 	}
 
 	return push.Push(ctx, sm, opt.ContentStore, imgObj.Target.Digest, image, insecure, registriesHosts, false)
-}
-
-func configurePushRegistries(scheme string) docker.RegistryHosts {
-	return func(host string) ([]docker.RegistryHost, error) {
-		config := docker.RegistryHost{
-			Client:       http.DefaultClient,
-			Authorizer:   nil,
-			Host:         host,
-			Scheme:       scheme,
-			Path:         "/v2",
-			Capabilities: docker.HostCapabilityPull | docker.HostCapabilityResolve | docker.HostCapabilityPush,
-		}
-
-		if config.Client == nil {
-			config.Client = http.DefaultClient
-		}
-
-		if host == "docker.io" {
-			config.Host = "registry-1.docker.io"
-		}
-
-		return []docker.RegistryHost{config}, nil
-	}
 }

--- a/pull.go
+++ b/pull.go
@@ -31,6 +31,10 @@ func newPullCommand() *cobra.Command {
 		},
 	}
 
+	fs := cmd.Flags()
+
+	fs.BoolVar(&pull.insecure, "insecure-registry", false, "Pull from insecure registry")
+
 	return cmd
 }
 
@@ -44,6 +48,7 @@ func validatePullImageArgs(cmd *cobra.Command, args []string) error {
 
 type pullCommand struct {
 	image string
+	insecure bool
 }
 
 func (cmd *pullCommand) Run(args []string) (err error) {
@@ -78,7 +83,7 @@ func (cmd *pullCommand) Run(args []string) (err error) {
 	eg.Go(func() error {
 		defer sess.Close()
 		var err error
-		listedImage, err = c.Pull(ctx, cmd.image)
+		listedImage, err = c.Pull(ctx, cmd.image, cmd.insecure)
 		return err
 	})
 	if err := eg.Wait(); err != nil {


### PR DESCRIPTION
Builds on #329 to add the ability to pull images from insecure HTTP registries. Tested with Docker `registry` image. 