### PR TITLE
CI on PR

### DIFF
--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -11,31 +11,8 @@ jobs:
     name: make all
     runs-on: ubuntu-latest
     steps:
-      - name: Determine ref
-        id: ref
-        run: |
-          ref=""
-
-          if [ "${{ github.event_name }}" == "push" ]; then
-            full_ref="${{ github.ref }}"
-            ref_without_ref="${full_ref##refs/}"
-            ref_without_heads="${ref_without_ref##heads/}"
-            ref="${ref_without_heads##tags/}"
-          elif [ "${{ github.event_name }}" == "pull_request" ]; then
-            ref="${{ github.head_ref }}"
-          else
-            echo "Something went VERY wrong!"
-            exit 5
-          fi
-
-          echo "Ref: ${ref}"
-          echo "::set-output name=ref::${ref}"
-
-      - name: Clone code
-        run: git clone --depth=1 --branch="${{ steps.ref.outputs.ref }}" -c core.autocrlf=false https://github.com/${{ github.repository }} .
-
+      - uses: actions/checkout@master
       - name: install deps
-        shell: bash
         run: |
           sudo apt install -y \
             libseccomp-dev \
@@ -43,33 +20,29 @@ jobs:
             uidmap \
             pigz \
             --no-install-recommends
-
+        shell: bash
       - uses: actions/setup-go@v2
         with:
           go-version: "^1.13.1" # The Go version to download (if necessary) and use.
-
       - name: install go tools
-        shell: bash
         run: |
           go get golang.org/x/lint/golint
           go get honnef.co/go/tools/cmd/staticcheck
           go get -u github.com/go-bindata/go-bindata/go-bindata
           sudo mkdir -p /run/runc
           sudo chown runner:runner -R /run/runc
-
+        shell: bash
       - name: make all
-        shell: bash
         run: make all
-
-      - name: Run Test Coverage
         shell: bash
+      - name: Run Test Coverage
         run: |
           make cover
           bash <(curl -s https://codecov.io/bash)
-
+        shell: bash
       - name: Run e2e Tests
-        env:
-          STATE_DIR: $HOME/img
         run: |
           make install
           ./contrib/e2e-dockerfiles-build-test.sh
+        env:
+          STATE_DIR: $HOME/img

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -1,12 +1,33 @@
-on: push
 name: make all
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
 jobs:
   makeall:
     name: make all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - name: Output ref for job
+        id: ref
+        run: |
+          if [ "${{ github.event_name }}" == "push" ]; then
+            echo "::set-output name=ref::master"
+          elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "::set-output name=ref::${{ github.head_ref }}"
+          else
+            echo "Something went VERY wrong!"
+            exit 5
+          fi
+
+      - name: Clone code
+        run: git clone --depth=1 --branch="${{ steps.ref.outputs.ref }}" -c core.autocrlf=false https://github.com/${{ github.repository }} .
+
       - name: install deps
+        shell: bash
         run: |
           sudo apt install -y \
             libseccomp-dev \
@@ -14,29 +35,33 @@ jobs:
             uidmap \
             pigz \
             --no-install-recommends
-        shell: bash
+
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.13.1' # The Go version to download (if necessary) and use.
+          go-version: "^1.13.1" # The Go version to download (if necessary) and use.
+
       - name: install go tools
+        shell: bash
         run: |
           go get golang.org/x/lint/golint
           go get honnef.co/go/tools/cmd/staticcheck
           go get -u github.com/go-bindata/go-bindata/go-bindata
           sudo mkdir -p /run/runc
           sudo chown runner:runner -R /run/runc
-        shell: bash
+
       - name: make all
-        run: make all
         shell: bash
+        run: make all
+
       - name: Run Test Coverage
+        shell: bash
         run: |
           make cover
           bash <(curl -s https://codecov.io/bash)
-        shell: bash
+
       - name: Run e2e Tests
+        env:
+          STATE_DIR: $HOME/img
         run: |
           make install
           ./contrib/e2e-dockerfiles-build-test.sh
-        env:
-          STATE_DIR: $HOME/img

--- a/.github/workflows/make-all.yml
+++ b/.github/workflows/make-all.yml
@@ -11,17 +11,25 @@ jobs:
     name: make all
     runs-on: ubuntu-latest
     steps:
-      - name: Output ref for job
+      - name: Determine ref
         id: ref
         run: |
+          ref=""
+
           if [ "${{ github.event_name }}" == "push" ]; then
-            echo "::set-output name=ref::master"
+            full_ref="${{ github.ref }}"
+            ref_without_ref="${full_ref##refs/}"
+            ref_without_heads="${ref_without_ref##heads/}"
+            ref="${ref_without_heads##tags/}"
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "::set-output name=ref::${{ github.head_ref }}"
+            ref="${{ github.head_ref }}"
           else
             echo "Something went VERY wrong!"
             exit 5
           fi
+
+          echo "Ref: ${ref}"
+          echo "::set-output name=ref::${ref}"
 
       - name: Clone code
         run: git clone --depth=1 --branch="${{ steps.ref.outputs.ref }}" -c core.autocrlf=false https://github.com/${{ github.repository }} .


### PR DESCRIPTION
Refers to #325

I'm unsure if this tackles all the desired behaviors. I made some assumptions about just targeting the `make-all` workflow for PRs, and kept the `push` event as well.

I've also not restricted the `push` event to any branches, but it could make sense to do so.

That would also simplify the ref-determining code in the case of the push-event as well.

Other than that, I tried to tidy up the file a bit. I find some whitespace between workflow steps helps to read yaml more (I look at this stuff a lot all day).

This workflow file _should_ go into effect/be observable on this PR, as this file exists in the default branch. But my experience with GitHub Actions has been somewhat inconsistent in this regard.

EDIT: Ah, yes, this is coming from a fork so the workflow file will need approved first!