### PR TITLE
Add --push and --load support to build cmd

### DIFF
--- a/build.go
+++ b/build.go
@@ -72,6 +72,8 @@ func newBuildCommand() *cobra.Command {
 	fs.Var(build.labels, "label", "Set metadata for an image")
 	fs.BoolVar(&build.noConsole, "no-console", false, "Use non-console progress UI")
 	fs.BoolVar(&build.noCache, "no-cache", false, "Do not use cache when building the image")
+	fs.BoolVar(&build.push, "push", false, "Shorthand for \"--output=type=registry\"")
+	fs.BoolVar(&build.load, "load", false, "Shorthand for \"--output=type=docker\"") // no-op flag
 	fs.StringVarP(&build.output, "output", "o", "", "BuildKit output specification (e.g. type=tar,dest=build.tar)")
 	fs.Var(build.cacheFrom, "cache-from", "Buildkit import-cache or Buildx cache-from specification")
 	fs.Var(build.cacheTo, "cache-to", "Buildx cache-to specification")
@@ -93,6 +95,8 @@ type buildCommand struct {
 	contextDir string
 	noConsole  bool
 	noCache    bool
+	push       bool
+	load       bool // no-op
 }
 
 // validateTag checks if the given image name can be resolved, and ensures the latest tag is added if it is missing.
@@ -113,6 +117,11 @@ func (cmd *buildCommand) ValidateArgs(c *cobra.Command, args []string) error {
 		return fmt.Errorf("must pass a path to build")
 	}
 
+	if cmd.push {
+		c.Flag("output").Changed = true
+		cmd.output = fmt.Sprintf("type=image,push=true,name=%s", cmd.tags.values[0])
+	}
+
 	if c.Flag("output").Changed {
 		out, err := build.ParseOutput([]string{cmd.output})
 		if err != nil || len(out) != 1 {
@@ -124,6 +133,11 @@ func (cmd *buildCommand) ValidateArgs(c *cobra.Command, args []string) error {
 				return err
 			}
 			out[0].Attrs["name"] = validated
+		}
+		if out[0].Type == "registry" {
+			out[0].Type = "image"
+			out[0].Attrs["push"] = "true"
+			cmd.push = true
 		}
 		cmd.bkoutput = out[0]
 	} else if cmd.tags.Len() < 1 {
@@ -255,6 +269,9 @@ func (cmd *buildCommand) Run(args []string) (err error) {
 				"name": strings.Join(cmd.tags.GetAll(), ","),
 			},
 		}
+	}
+	if cmd.push {
+		out.Attrs["name"] = strings.Join(cmd.tags.GetAll(), ",")
 	}
 
 	ch := make(chan *controlapi.StatusResponse)


### PR DESCRIPTION
## Problem statement

I found myself in the situation where I needed to give my users a migration path from `img` to `docker + buildkit`, which roughly translates into adding support to the `--push`, `--load` and `--output=type=registry` flags. 

I'm well aware this project is not longer maintained, as per expressed in #348; however, I wanted to put this PR out there in case someone else stumbles with a similar situation.

## Changeset Description

In summary, this _quick patch_ allows `img` to rehash buildkit's `output` attributes based on the new flags presence. 

The last statemet stands true with the only exception for the `--load` flag,  which I preferred to add as a dummy one since `img` already simulates a docker registry through its own implementation. However, if we need a fully complaint solution I would suggest to incoporate #327 first, then add the proper behavior to this flag (dump resulting `tar` in STDOUT and pipe it again through STDIN as separate process).