### PR TITLE
README.md: updated ebuild category to "app-containers"

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ $ makepkg -si
 
 #### Gentoo
 
-There is an [ebuild](https://github.com/gentoo/gentoo/tree/master/app-emulation/img).
+There is an [ebuild](https://github.com/gentoo/gentoo/tree/master/app-containers/img).
 
 ```console
-$ sudo emerge -a app-emulation/img
+$ sudo emerge -a app-containers/img
 ```
 
 #### Running with Docker


### PR DESCRIPTION
The ebuild has been relocated from the "app-emulation" category  to "app-containers", reflecting a previous adjustment. Refer to  commit https://github.com/gentoo/gentoo/commit/5e06cb4cc3d5942a4986cc90de5bdeafc21cb720 for further insights.